### PR TITLE
final changes to user table

### DIFF
--- a/database_init.sql
+++ b/database_init.sql
@@ -71,7 +71,7 @@ DROP TABLE IF EXISTS `trawell`.`carsharing` ;
 
 CREATE TABLE IF NOT EXISTS `trawell`.`carsharing` (
   `id` INT NOT NULL AUTO_INCREMENT,
-  `departureDate` DATETIME NOT NULL,
+  `departure_date` DATETIME NOT NULL,
   `destination` VARCHAR(500) NOT NULL,
   `departure` VARCHAR(45) NOT NULL,
   `arrival` VARCHAR(45) NOT NULL,

--- a/database_init.sql
+++ b/database_init.sql
@@ -67,27 +67,26 @@ ENGINE = InnoDB;
 -- -----------------------------------------------------
 -- Table `trawell`.`CarSharing`
 -- -----------------------------------------------------
-DROP TABLE IF EXISTS `trawell`.`CarSharing` ;
+DROP TABLE IF EXISTS `trawell`.`carsharing` ;
 
-CREATE TABLE IF NOT EXISTS `trawell`.`CarSharing` (
+CREATE TABLE IF NOT EXISTS `trawell`.`carsharing` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `departureDate` DATETIME NOT NULL,
-  `CarSharingDestination` VARCHAR(500) NOT NULL,
-  `CarSharingDeparture` VARCHAR(45) NOT NULL,
-  `CarSharingArrival` VARCHAR(45) NOT NULL,
-  `CarSharingSpot` INT NOT NULL,
+  `destination` VARCHAR(500) NOT NULL,
+  `departure` VARCHAR(45) NOT NULL,
+  `arrival` VARCHAR(45) NOT NULL,
+  `carsharingspot` INT NOT NULL,
   `idOwner` INT NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE INDEX `idCarSharing_UNIQUE` (`id` ASC))
+  PRIMARY KEY (`id`))
 ENGINE = InnoDB;
 
 
 -- -----------------------------------------------------
 -- Table `trawell`.`CarSpot`
 -- -----------------------------------------------------
-DROP TABLE IF EXISTS `trawell`.`CarSpot` ;
+DROP TABLE IF EXISTS `trawell`.`carspot` ;
 
-CREATE TABLE IF NOT EXISTS `trawell`.`CarSpot` (
+CREATE TABLE IF NOT EXISTS `trawell`.`carspot` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `idCarSharing` INT NOT NULL,
   `idUser` INT NOT NULL,
@@ -97,12 +96,12 @@ CREATE TABLE IF NOT EXISTS `trawell`.`CarSpot` (
   INDEX `idCarSharing_idx` (`idCarSharing` ASC),
  
     FOREIGN KEY (`idUser`)
-    REFERENCES `trawell`.`User` (`id`)
+    REFERENCES `trawell`.`user` (`id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION,
  
     FOREIGN KEY (`idCarSharing`)
-    REFERENCES `trawell`.`CarSharing` (`id`)
+    REFERENCES `trawell`.`carsharing` (`id`)
     ON DELETE NO ACTION
     ON UPDATE NO ACTION)
 ENGINE = InnoDB;
@@ -361,17 +360,17 @@ DROP TABLE IF EXISTS `trawell`.`user` ;
 CREATE TABLE IF NOT EXISTS `trawell`.`user` (
   `id` INT NOT NULL AUTO_INCREMENT,
   `mail` VARCHAR(254) NOT NULL,
-  `userName` VARCHAR(45) NOT NULL,
+  `username` VARCHAR(45) NOT NULL,
   `password` VARCHAR(45) NOT NULL,
   `name` VARCHAR(45) NOT NULL,
   `surname` VARCHAR(45) NOT NULL,
   `birth` DATETIME NOT NULL,
   `banned` TINYINT NOT NULL DEFAULT 0,
   `bio` VARCHAR(5000) default null,
-  `profilePhoto` INT DEFAULT 0,
+  `profile_photo` INT DEFAULT 0,
   `phone` VARCHAR(20) default null,
-  `isAdmin` TINYINT DEFAULT 0,
-  `isBanned` TINYINT DEFAULT 0,
+  `is_admin` TINYINT DEFAULT 0,
+  `is_banned` TINYINT DEFAULT 0,
   PRIMARY KEY (`id`, `mail`, `userName`),
   UNIQUE INDEX `idUser_UNIQUE` (`id` ASC),
   UNIQUE INDEX `mail_UNIQUE` (`mail` ASC),

--- a/src/main/java/com/trawell/controllers/RestUsersController.java
+++ b/src/main/java/com/trawell/controllers/RestUsersController.java
@@ -63,10 +63,15 @@ public class RestUsersController {
         User updatedUser = null;
         if (user != null && id == u.getId()) {
             
-            oldPassword = new Encoder(u.getUsername()).encoding(oldPassword, u.getUsername().length());
+            Encoder encode = new Encoder((u.getUsername()));
+            oldPassword = encode.encoding(oldPassword, u.getUsername().length());
+
             if (oldPassword.equals(u.getPassword())) {
+
+                user.setPassword(encode.encoding(user.getPassword(), user.getUsername().length()));
                 setBean(user, u);
                 updatedUser = userService.update(user);
+
             }
             else
                 return new ResponseEntity<User>(HttpStatus.NOT_ACCEPTABLE);
@@ -92,8 +97,11 @@ public class RestUsersController {
         User updatedUser = null;
         if (user != null && id == u.getId()) {
             
+            Encoder encode = new Encoder((u.getUsername()));
             oldPassword = new Encoder(u.getUsername()).encoding(oldPassword, u.getUsername().length());
+            
             if (oldPassword.equals(u.getPassword())) {
+                user.setPassword(encode.encoding(user.getPassword(), user.getUsername().length()));
                 setBean(user, u);
                 updatedUser = userService.update(user);
             }


### PR DESCRIPTION
JPA creava dei campi duplicati di isAdmin, profilePhoto e isBanned per via del fatto che non siano stati definiti nel seguente modo <prima parola>_<seconda parola> (es. is_banned). Inoltre è stato aggiunta anche la criptazione della password nella modifica degli utenti che erroneamente è stata tralasciata.